### PR TITLE
Retracted v2 releases

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -21,7 +21,7 @@ features:
     nameOverrides: 2.81.1
     unions: 2.85.0
 go:
-  version: 2.1.8
+  version: 2.1.11
   clientServerStatusCodesAsErrors: true
   flattenGlobalSecurity: true
   imports:

--- a/go.mod
+++ b/go.mod
@@ -29,3 +29,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )
+
+retract [v2.1.8, v2.1.11] // Accidentally bumped the major number. v1.X.X is the correct major version, please use that instead (go get github.com/conductorone/conductorone-sdk-go)


### PR DESCRIPTION
Bumping to v2 was a mistake, will publish these retractions which should break `go get .../v2` ensuring no one accidentally gets v2. 

### Next Steps
Once this release (2.1.11) gets picked up by https://proxy.golang.org/github.com/conductorone/conductorone-sdk-go/v2/@v/list it should cache the retractions and we can delete all v2 releases from our repo. Then we can change the main back to use v1 modules and it will be like nothing happened.

Also following up with speakeasy to prevent further major bumps

### Sources:
cannot go get when all versions are retracted - https://github.com/golang/go/issues/42648

The retract directive was added in Go 1.16. Go 1.15 and lower will report an error if a retract directive is written in the [main module’s](https://go.dev/ref/mod#glos-main-module) go.mod file and will ignore retract directives in go.mod files of dependencies. - https://go.dev/ref/mod#go-mod-file-retract