### PR TITLE
Use the background context when refreshing the token

### DIFF
--- a/extra_sdk_options.go
+++ b/extra_sdk_options.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 
 	"github.com/conductorone/conductorone-sdk-go/uhttp"
@@ -140,7 +141,10 @@ func NewWithCredentials(ctx context.Context, cred *ClientCredentials, opts ...Cu
 		options.ClientConfig = resp
 	}
 
-	tokenSource, err := NewTokenSource(ctx, cred.ClientID, cred.ClientSecret, options.GetServerURL())
+	// Create a long-lived context with the logger for the token source.
+	l := ctxzap.Extract(ctx)
+	tokenCtx := ctxzap.ToContext(context.Background(), l)
+	tokenSource, err := NewTokenSource(tokenCtx, cred.ClientID, cred.ClientSecret, options.GetServerURL())
 	if err != nil {
 		return nil, err
 	}

--- a/extra_sdk_options.go
+++ b/extra_sdk_options.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 
 	"github.com/conductorone/conductorone-sdk-go/uhttp"
@@ -141,10 +140,7 @@ func NewWithCredentials(ctx context.Context, cred *ClientCredentials, opts ...Cu
 		options.ClientConfig = resp
 	}
 
-	// Create a long-lived context with the logger for the token source.
-	l := ctxzap.Extract(ctx)
-	tokenCtx := ctxzap.ToContext(context.Background(), l)
-	tokenSource, err := NewTokenSource(tokenCtx, cred.ClientID, cred.ClientSecret, options.GetServerURL())
+	tokenSource, err := NewTokenSource(ctx, cred.ClientID, cred.ClientSecret, options.GetServerURL())
 	if err != nil {
 		return nil, err
 	}

--- a/token_source.go
+++ b/token_source.go
@@ -42,7 +42,6 @@ type c1Token struct {
 }
 
 type c1TokenSource struct {
-	ctx          context.Context
 	clientID     string
 	clientSecret *jose.JSONWebKey
 	tokenHost    string
@@ -138,7 +137,7 @@ func (c *c1TokenSource) Token() (*oauth2.Token, error) {
 		Path:   "auth/v1/token",
 	}
 
-	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, tokenUrl.String(), strings.NewReader(body.Encode()))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, tokenUrl.String(), strings.NewReader(body.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +180,6 @@ func NewTokenSource(ctx context.Context, clientID string, clientSecret string, t
 		return nil, err
 	}
 	return oauth2.ReuseTokenSource(nil, &c1TokenSource{
-		ctx:          ctx,
 		clientID:     clientID,
 		clientSecret: secret,
 		tokenHost:    strings.TrimLeft(tokenHost, "https://"),


### PR DESCRIPTION
We want to be sure this isn't cancelled for the lifetime of the process.