### PR TITLE
Further retracts versions, missed psuedo-versions

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -21,7 +21,7 @@ features:
     nameOverrides: 2.81.1
     unions: 2.85.0
 go:
-  version: 2.1.11
+  version: 2.1.12
   clientServerStatusCodesAsErrors: true
   flattenGlobalSecurity: true
   imports:

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 )
 
-retract [v2.1.8, v2.1.11] // Accidentally bumped the major number. v1.X.X is the correct major version, please use that instead (go get github.com/conductorone/conductorone-sdk-go)
+retract [v2.0.0-0, v2.1.12] // Accidentally bumped the major number. v1.X.X is the correct major version, please use that instead (go get github.com/conductorone/conductorone-sdk-go)


### PR DESCRIPTION
When running go get .../v2 it returns a pseudo version, according to the go docs this should wipe all versions including any pseudo-versions.