### PR TITLE
create WithExtraUserAgent

### DIFF
--- a/extra_sdk_options.go
+++ b/extra_sdk_options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -31,6 +32,12 @@ func WithTenant(input string) (SDKOption, error) {
 	}
 
 	return func(api *ConductoroneAPI) {}, nil
+}
+
+func WithExtraUserAgent(userAgent string) SDKOption {
+	return func(sdk *ConductoroneAPI) {
+		sdk.sdkConfiguration.UserAgent = fmt.Sprintf("%s %s", userAgent, sdk.sdkConfiguration.UserAgent)
+	}
 }
 
 type CustomSDKOption func(*CustomOptions)


### PR DESCRIPTION
Create a new SDKOption to prepend a custom user agent block. Useful for tools which wrap the SDK but still want to report their own info