### PR TITLE
Bump gen.yaml go.version to 1.28.0 for next regen

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -23,7 +23,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 go:
-  version: 1.26.1
+  version: 1.28.0
   additionalDependencies: {}
   allowUnknownFieldsInWeakUnions: false
   baseErrorName: ConductoroneAPIError


### PR DESCRIPTION
## Summary

Pre-stages a minor version bump in `gen.yaml` (`go.version: 1.26.1 → 1.28.0`) so the next Speakeasy regen produces v1.28.0.

## Why minor

The next regen ships:

- **Accumulated additive API surface since v1.27.x** — new service operations, request/response types, and shared models from ongoing API development.
- **A small set of type renames** consolidating internal Speakeasy-generated naming. The regen PR will document the rename map in its release notes.

A minor bump is the right cadence for additive surface plus the rename-consolidation set per standard semver.

## Mechanism

Speakeasy compares `gen.yaml`'s `<target>.version` against `.speakeasy/gen.lock`'s `releaseVersion`. When they mismatch, the next `speakeasy run` applies the gen.yaml value.

## Sequence

1. This PR merges first — pre-stages the version signal. No code regen yet.
2. Next Speakeasy regen (bot or manual `speakeasy run`) sees gen.yaml@1.28.0 vs gen.lock@1.26.1, applies the bump, regenerates, opens a PR.
3. Merge regen PR + tag v1.28.0.

## Test plan

- [x] `gen.yaml` syntactically valid (single-character version edit)
- [ ] After merge: confirm bot regen PR (or next manual `speakeasy run`) tags v1.28.0 and not a patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
